### PR TITLE
Fixed bug in `format_sigfig()` with trailing zeros for x < 0.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -86,7 +86,6 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 8.0.0
 Collate:
     'formatting_functions.R'
     'abnormal.R'
@@ -183,3 +182,4 @@ Collate:
     'utils_grid.R'
     'utils_rtables.R'
     'utils_split_funs.R'
+Config/roxygen2/version: 8.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@
 * Added `digits` argument to `h_tbl_median_surv()` and `control_surv_med_annot()` to control the `signif()` precision of the median survival time and confidence interval values annotated in `g_km()`. (#1469)
 
 ### Bug Fixes
+* Fixed bug in `format_sigfig()` with trailing zeros for x < 0.1 (#1510).
 * Fixed bug in `prop_diff_cmh()` which previously failed when strata combinations had 0 observations.
 * Fixed one-sided p-values in `prop_cmh()` with Wilson-Hilferty transformation — the sign of the effect was lost, producing incorrect p-values for `alternative = "less"` and `alternative = "greater"`.
 

--- a/R/formatting_functions.R
+++ b/R/formatting_functions.R
@@ -274,9 +274,12 @@ format_sigfig <- function(sigfig, format = "xx", num_fmt = "fg") {
   checkmate::assert_choice(format, c("xx", "xx / xx", "(xx, xx)", "xx - xx", "xx (xx)"))
   function(x, ...) {
     if (!is.numeric(x)) stop("`format_sigfig` cannot be used for non-numeric values. Please choose another format.")
-    num <- formatC(signif(x, digits = sigfig), digits = sigfig, format = num_fmt, flag = "#")
-    num <- gsub("\\.$", "", num) # remove trailing "."
-
+    num <- vapply(x, function(val) {
+      s <- signif(val, digits = sigfig)
+      flag <- if (!is.na(val) && abs(val) >= 0.1) "#" else ""
+      out <- formatC(s, digits = sigfig, format = num_fmt, flag = flag)
+      gsub("\\.$", "", out)
+    }, character(1))
     format_value(num, format)
   }
 }

--- a/tests/testthat/test-formatting_functions.R
+++ b/tests/testthat/test-formatting_functions.R
@@ -125,6 +125,15 @@ testthat::test_that("format_sigfig works with easy inputs", {
   testthat::expect_snapshot(res)
 })
 
+testthat::test_that("format_sigfig does not add trailing zeros for x < 0.1", {
+  fmt <- format_sigfig(3)
+  testthat::expect_identical(fmt(0.005), "0.005")
+  testthat::expect_identical(fmt(0.500), "0.500")
+  testthat::expect_identical(fmt(0.050), "0.05")
+  testthat::expect_identical(fmt(1.50), "1.50")
+  testthat::expect_identical(fmt(0.00123), "0.00123")
+})
+
 testthat::test_that("format_sigfig works with different format types", {
   test <- list(c(1.658, 0.5761), c(1e-1, 78.6), c(1234e-6, 200.00))
   z <- format_sigfig(3, "xx (xx)")


### PR DESCRIPTION
# Pull Request

Fixes #1510 
